### PR TITLE
Copy LICENSE file to /licenses

### DIFF
--- a/Containerfile.obs-api
+++ b/Containerfile.obs-api
@@ -17,6 +17,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS runner
 
 COPY --from=builder /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/
 COPY --from=builder /opt/observatorium-api /bin/observatorium-api
+COPY --from=builder /opt/LICENSE /licenses/.
 
 ARG BUILD_DATE
 ARG VERSION


### PR DESCRIPTION
This commit adds the LICENSE file to the /licenses directory in the container image which is expected by Konflux.